### PR TITLE
feat(ui): report errors to the user

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -27,7 +27,10 @@ declare type ResultMsg = {
 	filename: string;
 	blob: Blob;
 };
+declare type ErrorMsg = {
+	message: string;
+};
 declare type Msg = {
 	type: MsgType;
-	content: ReadyMsg | ResultMsg;
+	content: ReadyMsg | ResultMsg | ErrorMsg;
 };

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		%sveltekit.head%
 	</head>
 
-	<!-- NOTE: The `class-"absolute w-full"` is an ungodly hack to stop tooltips from
+	<!-- NOTE: The `class="absolute w-full"` is an ungodly hack to stop tooltips from
 	     zooming out the viewport of mobile users, scaling the entire page up and down...-->
 
 	<body data-sveltekit-preload-data="hover" data-theme="rocket" class="absolute w-full">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,9 +4,12 @@
 	import {
 		AppShell,
 		Drawer,
+		Modal,
 		ProgressBar,
 		storePopup,
-		initializeStores
+		initializeStores,
+		getModalStore,
+		type ModalSettings
 	} from '@skeletonlabs/skeleton';
 	import { computePosition, autoUpdate, flip, shift, offset, arrow } from '@floating-ui/dom';
 	import { onMount } from 'svelte';
@@ -23,9 +26,13 @@
 	import PGFinder from '$lib/pgfinder.ts?worker';
 	import { defaultPyio } from '$lib/constants';
 	import fileDownload from 'js-file-download';
+	import ErrorModal from './ErrorModal.svelte';
 
-	// Initialize Stores for Drawers
+	// Initialize Stores for Drawers and Modals
 	initializeStores();
+
+	// Get the Error Modal Store
+	const modalStore = getModalStore();
 
 	// Floating UI for Popups
 	storePopup.set({ computePosition, autoUpdate, flip, shift, offset, arrow });
@@ -55,6 +62,18 @@
 			} else if (type === 'Result') {
 				fileDownload(content.blob, content.filename);
 				processing = false;
+			} else if (type === 'Error') {
+				const modal: ModalSettings = {
+					type: 'component',
+					component: {
+						ref: ErrorModal,
+						props: {
+							message: content.message
+						}
+					}
+				};
+				modalStore.trigger(modal);
+				processing = false;
 			}
 		};
 	});
@@ -78,6 +97,8 @@
 	// transitions in their own threads, then maybe this will look nice...
 	$: animateWidth = !advancedMode ? 'transition-all' : '';
 </script>
+
+<Modal regionBackdrop="bg-surface-backdrop-token overflow-y-hidden" />
 
 <Drawer>
 	<LinksAndDownloads />

--- a/src/routes/ErrorModal.svelte
+++ b/src/routes/ErrorModal.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { getModalStore } from '@skeletonlabs/skeleton';
+	export let message: string;
+
+	const modalStore = getModalStore();
+	let traceVisible = false;
+
+	$: userError = message.match('(?<=pgfinder.errors.UserError: ).*');
+
+	$: traceHidden = traceVisible || !userError ? '' : 'hidden';
+	$: modalWidth = traceHidden ? 'w-modal-slim' : 'w-full max-w-3xl';
+</script>
+
+<div class="card flex flex-col gap-4 {modalWidth} max-h-[80vh] transition-all">
+	<header class="card-header">
+		{#if userError}
+			<h3 class="h3 text-center">Something Went Wrong</h3>
+		{:else}
+			<h3 class="h3 text-center">PGFinder Encountered an Error</h3>
+		{/if}
+	</header>
+	<p class="mx-4">
+		{#if userError}
+			{userError}
+		{:else}
+			PGFinder encountered an internal error that we've not come across before. Please
+			<a
+				href="https://github.com/Mesnage-Org/pgfinder/issues/new?labels=bug&template=bug_report.md"
+				class="anchor"
+				target="_blank"
+			>
+				create a bug report
+			</a> on GitHub and include the following error message:
+		{/if}
+	</p>
+	<div class="{traceHidden} mx-4 overflow-auto shadow bg-neutral-900/90 text-xs text-error-500">
+		<pre class="p-4 pt-1"><code>{message}</code></pre>
+	</div>
+	<footer class="card-footer flex flex-row-reverse justify-between">
+		<button type="button" class="btn variant-filled" on:click={() => modalStore.close()}
+			>Okay</button
+		>
+		{#if userError}
+			<button
+				type="button"
+				class="btn variant-filled-error"
+				on:click={() => (traceVisible = !traceVisible)}
+			>
+				{#if traceVisible}
+					Hide
+				{:else}
+					Show
+				{/if} Trace
+			</button>
+		{/if}
+	</footer>
+</div>


### PR DESCRIPTION
Tagging @bobturneruk since he was interested in seeing how the error handling works!

Pyodide makes it pretty easy, it converts Python exceptions to JS ones, so I just have to catch a "failed" Promise when running the Python to get an error message. The rest of this is mostly UI code.

I'm trying to be a bit clever, so any `UserError`s from `pgfinder` are displayed without the trace by default, and all other internal errors are displayed with the trace and a link to report an issue on the GitHub!